### PR TITLE
fix(tasks): correction de l'ordre des routes pour éviter les conflits

### DIFF
--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -15,6 +15,20 @@ export class TasksController {
     return this.tasksService.createTask(req.user, createTaskDto);
   }
 
+  @Get('next7days')
+  @UseGuards(RoleGuard)
+  @Permissions('tasks:read')
+  getTasksForNext7Days(@Req() req) {
+    return this.tasksService.getTasksForNext7Days(req.user);
+  }
+
+  @Get('all')
+  @UseGuards(RoleGuard)
+  @Permissions('tasks:read')
+  getAllTasksForUser(@Req() req) {
+    return this.tasksService.getAllTasksForUser(req.user);
+  }
+
   @Get()
   @UseGuards(RoleGuard)
   @Permissions('tasks:read')


### PR DESCRIPTION
- Déplacement des routes spécifiques (GET /tasks/next7days et GET /tasks/all) avant GET /tasks/:id
- Correction du conflit où ext7days était interprété comme un id
- Garantie que 	asks:read est bien utilisé pour toutes les requêtes GET
- Amélioration de la structure pour éviter les erreurs 403 Forbidden