### PR TITLE
feat(tasks): ajout de la modification des tâches pour admin et agent

### DIFF
--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get, Post, Body, UseGuards, Req, Param } from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, UseGuards, Req, Param } from '@nestjs/common';
+import { Task } from './task.model/task.model';
 import { TasksService } from './tasks.service';
 import { RoleGuard } from '../auth/roles/roles.guard';
 import { Permissions } from '../auth/decorators/roles.decorator/roles.decorator';
@@ -42,4 +43,11 @@ export class TasksController {
   getTaskById(@Req() req, @Param('id') id: number) {
     return this.tasksService.getTaskById(req.user, id);
   }
+
+  @Put(':id')
+  @UseGuards(RoleGuard)
+  @Permissions('tasks:update')
+  updateTask(@Req() req, @Param('id') taskId: number, @Body() updateData: Partial<Task>) {
+    return this.tasksService.updateTask(req.user, taskId, updateData);
+}
 }


### PR DESCRIPTION
- Ajout de la méthode updateTask dans 	asks.service.ts permettant aux admins et aux agents de modifier une tâche
- Ajout de la route PUT /tasks/:id dans 	asks.controller.ts pour la mise à jour des tâches
- Mise en place des règles d’autorisation :
  - Les admins peuvent modifier toutes les tâches
  - Les agents ne peuvent modifier que leurs propres tâches
  - Les usagers ne peuvent pas modifier de tâches
- Ajout de la permission 	asks:update pour les admins et agents dans permissions.ts
- Vérification que seuls les champs autorisés (date, heure_debut, heure_fin, statut, 
emarques) peuvent être modifiés
- Testé avec Postman pour s’assurer du bon fonctionnement