### PR TITLE
fix(tasks): correct date filtering for retrieving today's tasks

### DIFF
--- a/src/tasks/tasks.controller.ts
+++ b/src/tasks/tasks.controller.ts
@@ -16,28 +16,35 @@ export class TasksController {
     return this.tasksService.createTask(req.user, createTaskDto);
   }
 
-  @Get('next7days')
+  @Get('today') 
+  @UseGuards(RoleGuard)
+  @Permissions('tasks:read')
+  getTasksForToday(@Req() req) {
+    return this.tasksService.getTasksForToday(req.user);
+  }
+
+  @Get('next7days') 
   @UseGuards(RoleGuard)
   @Permissions('tasks:read')
   getTasksForNext7Days(@Req() req) {
     return this.tasksService.getTasksForNext7Days(req.user);
   }
 
-  @Get('all')
+  @Get('all') 
   @UseGuards(RoleGuard)
   @Permissions('tasks:read')
   getAllTasksForUser(@Req() req) {
     return this.tasksService.getAllTasksForUser(req.user);
   }
 
-  @Get()
+  @Get() 
   @UseGuards(RoleGuard)
   @Permissions('tasks:read')
   getAllTasks(@Req() req) {
     return this.tasksService.getAllTasks(req.user);
   }
 
-  @Get(':id')
+  @Get(':id') 
   @UseGuards(RoleGuard)
   @Permissions('tasks:read')
   getTaskById(@Req() req, @Param('id') id: number) {
@@ -49,5 +56,5 @@ export class TasksController {
   @Permissions('tasks:update')
   updateTask(@Req() req, @Param('id') taskId: number, @Body() updateData: Partial<Task>) {
     return this.tasksService.updateTask(req.user, taskId, updateData);
-}
+  }
 }

--- a/src/tasks/tasks.service.ts
+++ b/src/tasks/tasks.service.ts
@@ -147,4 +147,28 @@ export class TasksService {
   
     return updatedTask!;
   }
+
+  // Récupérer toutes les tâches pour aujourd'hui en fonction du rôle de l'utilisateur
+  async getTasksForToday(user: User): Promise<Task[]> {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    
+    const endOfToday = new Date();
+    endOfToday.setHours(23, 59, 59, 999);
+  
+    let whereCondition: any = {
+      date: { [Op.between]: [today, endOfToday] }
+    };
+  
+    if (user.role === 'agent') {
+      whereCondition.agent_id = user.id;
+    } else if (user.role === 'usager') {
+      whereCondition.usager_id = user.id;
+    }
+  
+    const tasks = await this.taskModel.findAll({ where: whereCondition });
+  
+    return tasks;
+  }
+  
 }


### PR DESCRIPTION
- Fixed issue where tasks were not retrieved due to direct DATE comparison with DATETIME
- Implemented Op.between to filter tasks scheduled between